### PR TITLE
Option to use volume keys to control media volume anytime (1/2)

### DIFF
--- a/res/values/abc_strings.xml
+++ b/res/values/abc_strings.xml
@@ -42,4 +42,8 @@
 
     <string name="double_tap_sleep_navbar">Double tap to sleep on navbar</string>
     <string name="swap_volume_buttons">Swap volume buttons rotation based</string>
+    
+    <!-- Volume key controls media stream -->
+    <string name="volume_keys_control_media_stream_title">Volume keys control media volume</string>
+    <string name="volume_keys_control_media_stream_summary">Force volume keys to control media stream</string>
 </resources>

--- a/res/xml/abc_volumerocker_settings.xml
+++ b/res/xml/abc_volumerocker_settings.xml
@@ -21,4 +21,11 @@
         android:key="swap_volume_buttons"
         android:title="@string/swap_volume_buttons"
         android:defaultValue="true" />
+
+    <com.abc.settings.preferences.SystemSettingSwitchPreference
+        android:key="volume_keys_control_media_stream"
+        android:title="@string/volume_keys_control_media_stream_title"
+        android:summary="@string/volume_keys_control_media_stream_summary"
+        android:defaultValue="false" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Some users don't adjust ringtone volume often (e.g. only use toggle to
switch between silent and non-silent) mode. Having an option to
use the volume keys to control media volume anytime allows media
volume to be controllled/muted before entering a game or other apps
with sound in an undesirable location.